### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Imitation jing.fm music playing view, support rotation and custom parameters.
 
 ![image](https://raw.github.com/isaced/JingRound/master/Screenshot.png)
 
-###使用说明(Usage)：
+### 使用说明(Usage)：
 
 可以在Storybord、Xib直接拖个View然后更改其类为`JingRoundView`，设置基本属性即可:
 
@@ -55,6 +55,6 @@ Of course, you need to import two framework:
 #import <CoreGraphics/CoreGraphics.h>
 ```
 
-###欢迎反馈(Welcomes feedback)：
+### 欢迎反馈(Welcomes feedback)：
 
 作者博客发布页面(Author)：[http://www.isaced.com/post-210.html](http://www.isaced.com/post-210.html) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
